### PR TITLE
Add ability to run database queries as prepared statements on database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.6.0] - 2018-12-20
+### Added
+- [DbConnection] Add `options` object to `query` and `bulkInsert` functions
+- [DbConnection] Add ability to run `query` and `bulkInsert` as prepared statements on the database via prepare and execute SQL commands
+- [DbConnection] Expose `escape` and `escapeId` helper functions from `mysql` library
+
 ## [2.5.0] - 2018-11-22
 ### Changed
 - Upgrade all dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-app-data-connectors",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Collection of libraries to provide an easy interface to common data sources",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
There have been some issues identified with how non-scalar data types get escaped within queries using question mark placeholders. Running queries via separate prepare and execute command, which splices the real values in the database instead of in the app, gets around this problem. Existing query functions will still default to the current method where the app will be performing the escaping.

## Changelog

### Added
- [DbConnection] Add `options` object to `query` and `bulkInsert` functions
- [DbConnection] Add ability to run `query` and `bulkInsert` as prepared statements on the database via prepare and execute SQL commands
- [DbConnection] Expose `escape` and `escapeId` helper functions from `mysql` library
